### PR TITLE
fix: theme reverted to default on route change, and toggle button would break until page was reloaded.

### DIFF
--- a/lib/handle-toggle-click.ts
+++ b/lib/handle-toggle-click.ts
@@ -11,8 +11,31 @@ async function startCircleAnimation(
     }
   }
 
+  const removeTemporaryStyles = () => {
+    const style = document.getElementById('temp-theme-transition-styles')
+    if (style) {
+      document.head.removeChild(style)
+    }
+  }
+
+  const injectTemporaryStyles = () => {
+    removeTemporaryStyles()
+    const style = document.createElement('style')
+    style.id = 'temp-theme-transition-styles'
+    style.textContent = `
+        ::view-transition-old(root),
+        ::view-transition-new(root) {
+            animation: none;
+            mix-blend-mode: normal;
+        }
+    `
+    document.head.appendChild(style)
+  }
+  injectTemporaryStyles()
+
   if (typeof doc.startViewTransition !== 'function') {
     callback()
+    removeTemporaryStyles()
     return
   }
 

--- a/lib/theme-script.astro
+++ b/lib/theme-script.astro
@@ -1,10 +1,34 @@
-<style is:global>
-  ::view-transition-old(root),
-  ::view-transition-new(root) {
-    animation: none;
-    mix-blend-mode: normal;
-  }
-</style>
 <script is:inline>
-"use strict";(()=>{(()=>{let t="theme-toggle";function o(){return window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light"}function l(){let e=localStorage.getItem(t);return e==="dark"||e==="light"?e:null}function n(){return l()||o()}function c(e){e===o()?localStorage.removeItem(t):localStorage.setItem(t,e)}function s(e){let m=document.documentElement;m.classList.toggle("dark",e==="dark"),m.style.colorScheme=e}function r(e){c(e),s(e)}r(n()),window.astroThemeToggle={setTheme:r,getTheme:n}})();})();
+  "use strict";
+  const themeToggle = () => {
+      (() => {
+          let t = "theme-toggle";
+          function o() {
+              return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+          }
+          function l() {
+              let e = localStorage.getItem(t);
+              return e === "dark" || e === "light" ? e : null;
+          }
+          function n() {
+              return l() || o();
+          }
+          function c(e) {
+              e === o() ? localStorage.removeItem(t) : localStorage.setItem(t, e);
+          }
+          function s(e) {
+              let m = document.documentElement;
+              m.classList.toggle("dark", e === "dark"), (m.style.colorScheme = e);
+          }
+          function r(e) {
+              c(e), s(e);
+          }
+          r(n()), (window.astroThemeToggle = { setTheme: r, getTheme: n });
+      })();
+  }
+  themeToggle();
+
+  document.addEventListener("astro:after-swap", () => {
+        themeToggle();
+    });
 </script>

--- a/website/components/theme-toggle-button.astro
+++ b/website/components/theme-toggle-button.astro
@@ -9,7 +9,11 @@
 
 <script>
   import { handleToggleClick } from 'astro-theme-toggle'
+
   document.getElementById('theme-toggle')?.addEventListener('click', handleToggleClick)
+  document.addEventListener("astro:after-swap", () => {
+        document.getElementById("theme-toggle")?.addEventListener("click", handleToggleClick);
+    });
 </script>
 
 <style is:global>

--- a/website/layouts/Layout.astro
+++ b/website/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import { ThemeScript } from 'astro-theme-toggle'
+import { ViewTransitions } from 'astro:transitions'
 
 interface Props {
   title: string
@@ -18,6 +19,7 @@ const { title } = Astro.props
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     <ThemeScript />
+    <ViewTransitions />
   </head>
   <body>
     <slot />

--- a/website/pages/about.astro
+++ b/website/pages/about.astro
@@ -5,16 +5,16 @@ import ThemeToggleButton from '../components/theme-toggle-button.astro'
 import Layout from '../layouts/Layout.astro'
 ---
 
-<Layout title="astro-theme-toggle">
+<Layout title="About page">
   <main>
     <AstroLogoBackground />
-    <h1>astro-theme-toggle</h1>
+    <h1>about page</h1>
     <div class="instructions">
       <span
         >Add a ripple-style theme toggle animation to your Astro project with
         ease</span
       >
-      <a href="/about">about</a>
+      <a href="/">home</a>
     </div>
     <div class="instructions">
       <ThemeToggleButton />


### PR DESCRIPTION
Added event listener for astro:after-swap to toggle the theme as it was being removed every time you moved to a new route. Same for the toggle-theme-button which had its event listener removed as well.

Removed the ::view-transition global styles as they blocked Astro's built in <ViewTransitions />. Instead dynamically added and removed them with js upon theme toggle.

Added about page link to showcase view-transitions.